### PR TITLE
[FIX] g2p_entitlement: _inherit instead of _name

### DIFF
--- a/spp_basic_cash_entitlement_spent/models/entitlement.py
+++ b/spp_basic_cash_entitlement_spent/models/entitlement.py
@@ -7,7 +7,7 @@ _logger = logging.getLogger(__name__)
 
 
 class G2PBasicEntitlementCashSpent(models.Model):
-    _name = "g2p.entitlement"
+    _inherit = "g2p.entitlement"
 
     spent_amount = fields.Monetary(
         required=True, currency_field="currency_id", default=0.0


### PR DESCRIPTION
## What this PR does?

Fix the mistake of using `_name` instead of `_inherit` made `g2p.programs` became a new model with not enough information for other table's relationship